### PR TITLE
perf エイプリルフールのif文評価を高速化

### DIFF
--- a/packages/client/src/widgets/calendar.vue
+++ b/packages/client/src/widgets/calendar.vue
@@ -76,7 +76,7 @@ const tick = () => {
 	const ny = now.getFullYear();
 
 	year.value = ny;
-	if (nm + 1 === 4 && nd === 1) { // エイプリルフール
+	if (nd === 1 && nm + 1 === 4) { // エイプリルフール
 		month.value = 3;
 		day.value = 32;
 	} else { // 通常


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
月よりも日付を先に評価するようにする

# Why
- JavaScriptの月は0始まりになっており月を評価する際に1を足す必要がある
ほんのちょっとコストがかかる月ではなく日（こちらは1始まり）が1であるかどうかを先に評価させることで毎秒の実行コストを抑えることができる

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
