### PR TITLE
feat: Mk:fetch(AiScript API)

### DIFF
--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -43,6 +43,7 @@ export function createAiScriptEnv(opts) {
 			utils.assertString(resource);
 			const response = init ? await fetch(resource.value, utils.valToJs(init)) : await fetch(resource.value);
 			const returnObject = {
+				status: response.status,
 				headers: new Object(),
 				body: await response.text(),
 			};

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -30,6 +30,23 @@ export function createAiScriptEnv(opts) {
 			const res = await os.api(ep.value, utils.valToJs(param), token ? token.value : (opts.token || null));
 			return utils.jsToVal(res);
 		}),
+		'Mk:restApi': values.FN_NATIVE(async ([url, method, body, headers]) => {
+			utils.assertString(url);
+			utils.assertString(method);
+			utils.assertString(body);
+			utils.assertObject(headers);
+
+			const typedHeaders = new Headers();
+			headers.value.forEach((value, key) => {
+				typedHeaders.set(key, utils.valToString(value));
+			});
+			const response = await fetch(url.value, {
+				method: method.value,
+				headers: typedHeaders,
+				body: body.value,
+			});
+			return utils.jsToVal(response.json());
+		}),
 		'Mk:save': values.FN_NATIVE(([key, value]) => {
 			utils.assertString(key);
 			localStorage.setItem('aiscript:' + opts.storageKey + ':' + key.value, JSON.stringify(utils.valToJs(value)));

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -39,7 +39,7 @@ export function createAiScriptEnv(opts) {
 			utils.assertString(key);
 			return utils.jsToVal(JSON.parse(localStorage.getItem('aiscript:' + opts.storageKey + ':' + key.value)));
 		}),
-		'Mk:restApi': values.FN_NATIVE(async ([url, method, body, headers]) => {
+		'Mk:fetch': values.FN_NATIVE(async ([url, method, body, headers]) => {
 			const init: {method?: string, body?: string, headers?: Headers} = new Object();
 			utils.assertString(url);
 			if (method) {

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -58,7 +58,10 @@ export function createAiScriptEnv(opts) {
 				});
 				init.headers = typedHeaders;
 			}
+
 			const response = await fetch(url.value, init);
+
+			// Parsing Section
 			const contentType = response.headers.get('Content-Type');
 			if (contentType === null) {
 				return utils.jsToVal(await response.text());
@@ -70,6 +73,7 @@ export function createAiScriptEnv(opts) {
 				const parser = new DOMParser();
 				return utils.jsToVal(parser.parseFromString((await response.text()), 'application/xml'));
 			}
+			// Content-Type不明
 			return utils.jsToVal(await response.text());
 		}),
 	};

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -39,27 +39,16 @@ export function createAiScriptEnv(opts) {
 			utils.assertString(key);
 			return utils.jsToVal(JSON.parse(localStorage.getItem('aiscript:' + opts.storageKey + ':' + key.value)));
 		}),
-		'Mk:fetch': values.FN_NATIVE(async ([url, method, body, headers]) => {
-			const init: {method?: string, body?: string, headers?: Headers} = new Object();
-			utils.assertString(url);
-			if (method) {
-				utils.assertString(method);
-				init.method = method.value;
-			}
-			if (body) {
-				utils.assertString(body);
-				init.body = body.value;
-			}
-			if (headers) {
-				utils.assertObject(headers);
-				const typedHeaders = new Headers();
-				headers.value.forEach((value, key) => {
-					typedHeaders.set(key, utils.valToString(value));
-				});
-				init.headers = typedHeaders;
-			}
-
-			const response = await fetch(url.value, init);
+		'Mk:fetch': values.FN_NATIVE(async ([resource, init]) => {
+			utils.assertString(resource);
+			const response = await (async () => {
+				if (init) {
+					utils.assertObject(init);
+					return await fetch(resource.value, utils.valToJs(init));
+				} else {
+					return await fetch(resource.value);
+				}
+			})();
 
 			// Parsing Section
 			const contentType = response.headers.get('Content-Type');

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -41,14 +41,7 @@ export function createAiScriptEnv(opts) {
 		}),
 		'Mk:fetch': values.FN_NATIVE(async ([resource, init]) => {
 			utils.assertString(resource);
-			const response = await (async () => {
-				if (init) {
-					utils.assertObject(init);
-					return await fetch(resource.value, utils.valToJs(init));
-				} else {
-					return await fetch(resource.value);
-				}
-			})();
+			const response = init ? await fetch(resource.value, utils.valToJs(init)) : await fetch(resource.value);
 			const returnObject = {
 				headers: new Object(),
 				body: await response.text(),
@@ -56,7 +49,6 @@ export function createAiScriptEnv(opts) {
 			response.headers.forEach((value, key) => {
 				returnObject.headers[key] = value;
 			});
-			console.log(returnObject)
 			return utils.jsToVal(returnObject);
 		}),
 	};

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -49,7 +49,15 @@ export function createAiScriptEnv(opts) {
 					return await fetch(resource.value);
 				}
 			})();
-			return utils.jsToVal(await response.text());
+			const returnObject = {
+				headers: new Object(),
+				body: await response.text(),
+			};
+			response.headers.forEach((value, key) => {
+				returnObject.headers[key] = value;
+			});
+			console.log(returnObject)
+			return utils.jsToVal(returnObject);
 		}),
 	};
 }

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -49,20 +49,6 @@ export function createAiScriptEnv(opts) {
 					return await fetch(resource.value);
 				}
 			})();
-
-			// Parsing Section
-			const contentType = response.headers.get('Content-Type');
-			if (contentType === null) {
-				return utils.jsToVal(await response.text());
-			}
-			if (contentType.includes('json')) {
-				return utils.jsToVal(await response.json());
-			}
-			if (contentType.includes('xml')) {
-				const parser = new DOMParser();
-				return utils.jsToVal(parser.parseFromString((await response.text()), 'application/xml'));
-			}
-			// Content-Type不明
 			return utils.jsToVal(await response.text());
 		}),
 	};

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -66,10 +66,10 @@ export function createAiScriptEnv(opts) {
 			if (contentType === null) {
 				return utils.jsToVal(await response.text());
 			}
-			if (contentType.includes('application/json')) {
+			if (contentType.includes('json')) {
 				return utils.jsToVal(await response.json());
 			}
-			if (contentType.includes('application/xml') || contentType.includes('text/xml')) {
+			if (contentType.includes('xml')) {
 				const parser = new DOMParser();
 				return utils.jsToVal(parser.parseFromString((await response.text()), 'application/xml'));
 			}

--- a/packages/client/src/scripts/aiscript/api.ts
+++ b/packages/client/src/scripts/aiscript/api.ts
@@ -30,6 +30,15 @@ export function createAiScriptEnv(opts) {
 			const res = await os.api(ep.value, utils.valToJs(param), token ? token.value : (opts.token || null));
 			return utils.jsToVal(res);
 		}),
+		'Mk:save': values.FN_NATIVE(([key, value]) => {
+			utils.assertString(key);
+			localStorage.setItem('aiscript:' + opts.storageKey + ':' + key.value, JSON.stringify(utils.valToJs(value)));
+			return values.NULL;
+		}),
+		'Mk:load': values.FN_NATIVE(([key]) => {
+			utils.assertString(key);
+			return utils.jsToVal(JSON.parse(localStorage.getItem('aiscript:' + opts.storageKey + ':' + key.value)));
+		}),
 		'Mk:restApi': values.FN_NATIVE(async ([url, method, body, headers]) => {
 			const init: {method?: string, body?: string, headers?: Headers} = new Object();
 			utils.assertString(url);
@@ -62,15 +71,6 @@ export function createAiScriptEnv(opts) {
 				return utils.jsToVal(parser.parseFromString((await response.text()), 'application/xml'));
 			}
 			return utils.jsToVal(await response.text());
-		}),
-		'Mk:save': values.FN_NATIVE(([key, value]) => {
-			utils.assertString(key);
-			localStorage.setItem('aiscript:' + opts.storageKey + ':' + key.value, JSON.stringify(utils.valToJs(value)));
-			return values.NULL;
-		}),
-		'Mk:load': values.FN_NATIVE(([key]) => {
-			utils.assertString(key);
-			return utils.jsToVal(JSON.parse(localStorage.getItem('aiscript:' + opts.storageKey + ':' + key.value)));
 		}),
 	};
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What

Misskey組み込みのAiScript関数として  
JavaScriptのFetch APIと同等のリクエスト処理を行うことのできる関数
  
`Mk:fetch(resource: str, init?: obj): obj`  
  
を追加します。

### 引数

- 第1引数resource: リクエストするURL: str（JavaScriptのfetch()の第1引数）
- 第2引数init(オプション): bodyや使用するHTTPメソッドの種類、リクエストする際に付加するヘッダーなどを格納したオブジェクト: obj（JavaScriptのfetch()の第2引数）

### 返り値

obj
```
{
  status: num,
  headers: obj,
  body: str
}
```
`status`にレスポンスのステータスコード  
`headers`にレスポンスヘッダーの{key: value}が入ったオブジェクト  
`body`にレスポンスの本文  
が入ったオブジェクトを返します

備考: [fetch() - MDN](https://developer.mozilla.org/ja/docs/Web/API/fetch)

# Why

現状のAiScript on MisskeyではMisskeyのブラウジングコンテキスト内で直接外部のREST APIなどを叩くことはできません。  
関連する裏技として`Plugin:open_url(url)`でブラウザー別タブからAPIのエンドポイントを開くことでGETリクエストのみ送信することが可能ですが、返ってきた値をAiScriptで利用することはできませんし「別タブでAPIレスポンスが表示される」→「タブを閉じてMisskeyに戻る」のはユーザビリティーの観点からちょっぴり微妙です。  
  
本実装により、CORSが許容されているURLの範囲内には限られますが外部のAPIレスポンスをAiScriptで利用するなど、AiScriptを用いたMisskeyプラグインなどの活用範囲が広がると思います。  
ウィジェットにエアコンを操作するボタンを設置するなどが可能に🥰

# Additional info (optional)

CORSで弾かれたときなどのネットワークエラーが発生した際は何も値が返りませんが、AiScriptでのエラーハンドリングの手法が定まっていないこと及びブラウザーのコンソールにエラーが出力されることから本実装のスコープ外としています。